### PR TITLE
Dapp: Update energy at account switch

### DIFF
--- a/dapp/src/client/scripts/app.jsx
+++ b/dapp/src/client/scripts/app.jsx
@@ -25,6 +25,7 @@ export class App extends React.Component {
     this.priceBond = new Bond();
     bonds.head.tie(this.getSellerContracts.bind(this));
     bonds.me.tie(this.getAccount.bind(this));
+    bonds.me.tie(this.getSellerContracts.bind(this));
   }
 
   async getAccount() {


### PR DESCRIPTION
Currently, switching account does not lead to update of energy balance,
this is due to energy balance is not tied to account bond, but only to
head bond